### PR TITLE
Update rgtan_main.py

### DIFF
--- a/methods/rgtan/rgtan_main.py
+++ b/methods/rgtan/rgtan_main.py
@@ -82,7 +82,7 @@ def rgtan_main(feat_df, graph, train_idx, test_idx, labels, args, cat_features, 
                       drop=args['dropout'],
                       device=device,
                       gated=args['gated'],
-                      ref_df=feat_df.iloc[train_idx],
+                      ref_df=feat_df,
                       cat_features=cat_feat,
                       neigh_features=nei_feat,
                       nei_att_head=nei_att_head).to(device)

--- a/methods/stagn/stagn_main.py
+++ b/methods/stagn/stagn_main.py
@@ -87,7 +87,7 @@ def stagn_main(
     device="cpu",
 ):
     train_idx, test_idx = train_test_split(
-        np.arange(features.shape[0]), test_size=test_ratio)
+        np.arange(features.shape[0]), test_size=test_ratio, stratify=labels)
 
     # y_pred = np.zeros(shape=test_label.shape)
     if mode == "2d":


### PR DESCRIPTION
BUG FIXED.
由于DGL的数据加载器的input_nodes会加载种子节点的邻居节点（两层），然后在 S-FFSD 数据集上，会刚好把图中的一些不在训练集的节点给加载进来用于模型输出。而模型本身在示例化的时候，是仅仅使用训练集数据的范围来初始化embedding层（用于为Location等特征编码的层），所以当模型输入DataLoader迭代出的input_nodes时，可能出现某些节点的cat_feat的值不在编码器的范围内，导致出错。 而加载模型时用的参数ref_df，本身只在初始化embedding层时使用了，所以从 feat_df.iloc[train_idx]变成feat_df，并不会导致信息泄露，并且这样修改后，将不会再出现上述Bug。